### PR TITLE
integrate vmod_oidc into pkg-varnish-cache

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -87,6 +87,7 @@ jobs:
           - vmod-reqwest
           - vmod-rers
           - vmod-k8s-endpoint
+          - vmod-oidc
         exclude:
           # no mhash-devel
           - target: almalinux-10-rpm

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can check the authoritative liste of packages and the actual version of each
 - [vmod-fileserver](https://github.com/varnish-rs/vmod-fileserver/): use a filesystem as backend
 - [vmod-geoip2](https://github.com/varnishcache-friends/libvmod-geoip2/): load and query `mmdb` databases
 - [vmod-jq](https://github.com/varnishcache-friends/libvmod-jq/): parse and manipulate JSON strings
+- [vmod-oidc](https://github.com/perbu/vmod_oidc/): OpenID Connect authentication for Varnish
 - [vmod-querystring](https://git.sr.ht/~dridi/vmod-querystring/): filter and sanitize querystring parameters
 - [vmod-redis](https://github.com/carlosabalde/libvmod-redis/): query `redis`/`valkey` databases from VCL
 - [vmod-reqwest](https://github.com/varnish-rs/vmod-reqwest/): dynamic backends and HTTP requests (support HTTPS and HTTP/2, as well as Brotly)

--- a/build_scripts/main.vtc
+++ b/build_scripts/main.vtc
@@ -5,6 +5,7 @@ varnish v1 -vcl {
 
 	import fileserver;
 	import jq;
+	import oidc;
 	import querystring;
 	import redis;
 	import reqwest;

--- a/pkg.env
+++ b/pkg.env
@@ -1,4 +1,4 @@
-package_release=4
+package_release=5
 
 declare -A VARS
 VARS[varnish_version]=9.0.3

--- a/pkg.env
+++ b/pkg.env
@@ -33,6 +33,10 @@ VARS[vmod-k8s-endpoint_version]=0.1.0
 VARS[vmod-k8s-endpoint_source]=https://github.com/varnish/vmod-k8s_endpoint/archive/refs/tags/v${VARS[vmod-k8s-endpoint_version]}.tar.gz
 VARS[vmod-k8s-endpoint_sha512]=f8242b1d8ddc7b9c32a88e4e22734018f2aaa9cb325dc118a36ccacda639d305e1cbc1d3a06a0540a6c572e8b347230c5f868cfefcb9cbc60617a6e94bfef83a
 
+VARS[vmod-oidc_version]=0.2.0
+VARS[vmod-oidc_source]=https://github.com/perbu/vmod_oidc/archive/refs/tags/v${VARS[vmod-oidc_version]}.tar.gz
+VARS[vmod-oidc_sha512]=5655a747c4d79ddc282ee9a771d9c4936b5f0c6a026469efe6a1bfd259eb0eb7cfc4dde914d9d59004d025a862513145f49f4b71482045c353654b000e0164b9
+
 VARS[vmod-querystring_version]=2.0.4
 VARS[vmod-querystring_source]=https://git.sr.ht/~dridi/vmod-querystring/refs/download/vmod-querystring-2.0.4/vmod-querystring-${VARS[vmod-querystring_version]}.tar.gz
 VARS[vmod-querystring_sha512]=609e333279f761e4bb4867f4541003eccf71df06ff4631834e66f3b384d49e1e66dd7fa7ff500717b4a7db215838418f05406a431d19af7e03a61321646422cf

--- a/vmod-oidc/arch/.gitignore
+++ b/vmod-oidc/arch/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!PKGBUILD.tmpl

--- a/vmod-oidc/arch/PKGBUILD.tmpl
+++ b/vmod-oidc/arch/PKGBUILD.tmpl
@@ -10,7 +10,7 @@ arch=('x86_64')
 url="https://github.com/perbu/vmod_oidc"
 license=('BSD-2-Clause')
 depends=("varnish=$pkgver-$pkgrel")
-makedepends=('cargo' 'clang' 'openssl' 'pkg-config' 'python-docutils' 'jq')
+makedepends=('cargo' 'clang' 'openssl' 'pkg-config')
 source=("$pkgname-$_srcver.tar.gz::https://github.com/perbu/vmod_oidc/archive/refs/tags/v${_srcver}.tar.gz")
 sha512sums=('SKIP')
 options=(!lto)

--- a/vmod-oidc/arch/PKGBUILD.tmpl
+++ b/vmod-oidc/arch/PKGBUILD.tmpl
@@ -1,0 +1,32 @@
+# Maintainer: Varnish Software <opensource@varnish-software.com>
+
+pkgname=vmod-oidc
+pkgver=@PKGVER@
+pkgrel=@PKGREL@
+_srcver=@SRCVER@
+_srcname=vmod_oidc
+pkgdesc="OpenID Connect authentication VMOD for Varnish"
+arch=('x86_64')
+url="https://github.com/perbu/vmod_oidc"
+license=('BSD-2-Clause')
+depends=("varnish=$pkgver-$pkgrel")
+makedepends=('cargo' 'clang' 'openssl' 'pkg-config' 'python-docutils' 'jq')
+source=("$pkgname-$_srcver.tar.gz::https://github.com/perbu/vmod_oidc/archive/refs/tags/v${_srcver}.tar.gz")
+sha512sums=('SKIP')
+options=(!lto)
+
+prepare() {
+    cd "$_srcname-$_srcver"
+    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+    cd "$_srcname-$_srcver"
+    cargo build --frozen --release --features vmod
+}
+
+package() {
+    cd "$_srcname-$_srcver"
+    install -Dt "$pkgdir/$(pkg-config varnishapi --variable=vmoddir)" target/release/*.so
+    install -Dm644 "LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE.md"
+}

--- a/vmod-oidc/debian/control
+++ b/vmod-oidc/debian/control
@@ -1,0 +1,30 @@
+Source: vmod-oidc
+Section: net
+Priority: extra
+Maintainer: Varnish Software <opensource@varnish-software.com>
+Build-Depends:
+ build-essential,
+ cargo,
+ debhelper (>= 9),
+ debhelper-compat (= 11),
+ jq,
+ libclang-dev,
+ libssl-dev,
+ pkg-config,
+ python3-docutils,
+ varnish,
+ varnish-dev,
+Standards-Version: 3.9.5
+Vcs-Git: git://github.com/perbu/vmod_oidc.git
+
+Package: vmod-oidc
+Architecture: any
+Depends:
+ varnish (= ${binary:Version}),
+ ${varnishd:ABI},
+ ${shlibs:Depends},
+ ${misc:Depends},
+Description: OpenID Connect authentication VMOD for Varnish
+ Allows Varnish to act as an OpenID Connect Relying Party, authenticating
+ users against any OIDC-compliant identity provider before serving cached
+ content. Sessions are stateless and cookie-based.

--- a/vmod-oidc/debian/control
+++ b/vmod-oidc/debian/control
@@ -7,11 +7,9 @@ Build-Depends:
  cargo,
  debhelper (>= 9),
  debhelper-compat (= 11),
- jq,
  libclang-dev,
  libssl-dev,
  pkg-config,
- python3-docutils,
  varnish,
  varnish-dev,
 Standards-Version: 3.9.5

--- a/vmod-oidc/debian/rules
+++ b/vmod-oidc/debian/rules
@@ -1,0 +1,26 @@
+#!/usr/bin/make -f
+DEB_BUILD_OPTIONS=noddebs
+
+CARGO=~/.cargo/bin/cargo
+
+%:
+	dh $@ --parallel
+
+VARNISHD_ABI = $(shell varnishd -V 2>&1 | sed -En 's/.*revision ([0-9a-f]*).*/\1/p')
+
+override_dh_gencontrol:
+	echo "varnishd:ABI=varnishd-abi-$(VARNISHD_ABI)" >> debian/substvars
+	dh_gencontrol -- -Tdebian/substvars
+
+override_dh_auto_configure:
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+	${CARGO} fetch --locked
+
+override_dh_auto_build:
+	${CARGO} build --frozen --release --features vmod
+
+override_dh_auto_install:
+	install -Dt debian/vmod-oidc/usr/lib/varnish/vmods/ target/release/libvmod_oidc.so
+
+override_dh_auto_test:
+	export RUST_BACKTRACE=1; ${CARGO} test --frozen --release --features vmod --lib

--- a/vmod-oidc/redhat/vmod-oidc.spec
+++ b/vmod-oidc/redhat/vmod-oidc.spec
@@ -8,7 +8,6 @@ URL:     https://github.com/perbu/vmod_oidc
 Source:  %{srcurl}
 
 BuildRequires: 	openssl-devel
-BuildRequires: 	jq
 BuildRequires: 	cargo
 BuildRequires: 	clang-devel
 BuildRequires:  varnish-devel = %{version}-%{release}

--- a/vmod-oidc/redhat/vmod-oidc.spec
+++ b/vmod-oidc/redhat/vmod-oidc.spec
@@ -1,0 +1,51 @@
+Name:    vmod-oidc
+Version: %{versiontag}
+Release: %{releasetag}%{?dist}
+Summary: OpenID Connect authentication VMOD for Varnish
+
+License: BSD-2-Clause
+URL:     https://github.com/perbu/vmod_oidc
+Source:  %{srcurl}
+
+BuildRequires: 	openssl-devel
+BuildRequires: 	jq
+BuildRequires: 	cargo
+BuildRequires: 	clang-devel
+BuildRequires:  varnish-devel = %{version}-%{release}
+
+Requires: 	varnish = %{version}-%{release}
+
+%description
+Allows Varnish to act as an OpenID Connect Relying Party, authenticating
+users against any OIDC-compliant identity provider before serving cached
+content. Sessions are stateless and cookie-based.
+
+
+%prep
+%setup -q -n vmod_oidc-%{srcversion}
+cargo fetch --locked
+
+
+%build
+
+cargo build --frozen --release --features vmod -j12
+
+
+%install
+install -Dt %{buildroot}/$(pkg-config varnishapi --variable=vmoddir) target/release/libvmod_oidc.so
+
+
+%check
+export RUST_BACKTRACE=1
+cargo test --frozen --release --features vmod --lib
+
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/varnish/vmods/libvmod_oidc.so
+
+
+%changelog
+* Mon Dec 01 2025 Varnish Software <opensource@varnish-software.com> - 1.0.0
+- This changelog is not in use.


### PR DESCRIPTION
Adds packaging for [vmod-oidc](https://github.com/perbu/vmod_oidc) (OpenID Connect authentication for Varnish), following the existing pattern used by other Rust-based vmods in this repo.

New files:

- `vmod-oidc/arch/PKGBUILD.tmpl` — Arch package build script
- `vmod-oidc/debian/control` and `vmod-oidc/debian/rules` — Debian packaging
- `vmod-oidc/redhat/vmod-oidc.spec` — RPM spec

Modified files:

- `pkg.env` — added version (0.2.0, latest tag), source URL, and sha512 checksum
- `README.md` — added vmod-oidc to the list of packaged tools

Note: unlike the `vmod-rers` template, `vmod_oidc`'s Varnish bindings sit behind a `vmod` Cargo feature, so all three build/test steps use `cargo build/test --features vmod` (plain cargo build alone produces a .so with no VMOD entry points). Also followed the `vmod-k8s-endpoint` pattern for the package-name/repo-name mismatch, since the upstream repo is `vmod_oidc` (underscore) while the package is named `vmod-oidc` (hyphen) to match this repo's convention.